### PR TITLE
Improved memory usage

### DIFF
--- a/Novocaine.xcodeproj/project.pbxproj
+++ b/Novocaine.xcodeproj/project.pbxproj
@@ -120,14 +120,6 @@
 		FA552628152A63A4003D9601 = {
 			isa = PBXGroup;
 			children = (
-				FA5526EB152A6466003D9601 /* Accelerate.framework */,
-				FA5526EC152A6466003D9601 /* AudioToolbox.framework */,
-				FA5526ED152A6466003D9601 /* AudioUnit.framework */,
-				FA5526EE152A6466003D9601 /* CoreAudio.framework */,
-				FA55269D152A6405003D9601 /* Accelerate.framework */,
-				FA55269E152A6405003D9601 /* AudioToolbox.framework */,
-				FA55269F152A6405003D9601 /* AudioUnit.framework */,
-				FA5526A0152A6405003D9601 /* CoreAudio.framework */,
 				FA552694152A63F6003D9601 /* Novocaine */,
 				FA55267F152A63B6003D9601 /* Novocaine Mac Example */,
 				FA5526D3152A6452003D9601 /* Novocaine iOS Example */,
@@ -148,9 +140,17 @@
 		FA552636152A63A4003D9601 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				FA552637152A63A4003D9601 /* UIKit.framework */,
-				FA552639152A63A4003D9601 /* Foundation.framework */,
+				FA5526EB152A6466003D9601 /* Accelerate.framework */,
+				FA55269D152A6405003D9601 /* Accelerate.framework */,
+				FA5526EC152A6466003D9601 /* AudioToolbox.framework */,
+				FA55269E152A6405003D9601 /* AudioToolbox.framework */,
+				FA5526ED152A6466003D9601 /* AudioUnit.framework */,
+				FA55269F152A6405003D9601 /* AudioUnit.framework */,
+				FA5526EE152A6466003D9601 /* CoreAudio.framework */,
+				FA5526A0152A6405003D9601 /* CoreAudio.framework */,
 				FA55263B152A63A4003D9601 /* CoreGraphics.framework */,
+				FA552639152A63A4003D9601 /* Foundation.framework */,
+				FA552637152A63A4003D9601 /* UIKit.framework */,
 				FA55265D152A63AE003D9601 /* Cocoa.framework */,
 				FA55265F152A63AE003D9601 /* Other Frameworks */,
 			);
@@ -193,8 +193,8 @@
 		FA552694152A63F6003D9601 /* Novocaine */ = {
 			isa = PBXGroup;
 			children = (
-				FA2015EC154B0DA700F8D3AC /* AudioFileWriter.m */,
 				FA2015EB154B0D9B00F8D3AC /* AudioFileWriter.h */,
+				FA2015EC154B0DA700F8D3AC /* AudioFileWriter.m */,
 				FA552695152A63F6003D9601 /* Novocaine.h */,
 				FA552696152A63F6003D9601 /* Novocaine.m */,
 				FA552697152A63F6003D9601 /* RingBuffer.h */,

--- a/Novocaine/AudioFileReader.h
+++ b/Novocaine/AudioFileReader.h
@@ -58,6 +58,7 @@
 //- (float)getCurrentTime;
 - (void)play;
 - (void)pause;
+- (void)stop;
 
 
 @end

--- a/Novocaine/AudioFileReader.mm
+++ b/Novocaine/AudioFileReader.mm
@@ -32,7 +32,6 @@
     RingBuffer *ringBuffer;
 }
 
-@property RingBuffer *ringBuffer;
 @property AudioStreamBasicDescription outputFormat;
 @property ExtAudioFileRef inputFile;
 @property UInt32 outputBufferSize;
@@ -52,7 +51,6 @@
 
 @implementation AudioFileReader
 
-@synthesize ringBuffer = _ringBuffer;
 @synthesize outputFormat = _outputFormat;
 @synthesize inputFile = _inputFile;
 @synthesize outputBuffer = _outputBuffer;
@@ -275,6 +273,15 @@
     // Pause the dispatch timer for retrieving the MP3 audio
     if (self.callbackTimer) {
         dispatch_suspend(self.callbackTimer);
+        self.playing = FALSE;
+    }
+}
+
+- (void)stop
+{
+    // Release the dispatch timer because it holds a reference to this class instance
+    if (self.callbackTimer) {
+        dispatch_release(self.callbackTimer);
         self.playing = FALSE;
     }
 }

--- a/Novocaine/Novocaine.m
+++ b/Novocaine/Novocaine.m
@@ -154,12 +154,16 @@ static Novocaine *audioManager = nil;
 #pragma mark - Block Handling
 - (void)setInputBlock:(InputBlock)newInputBlock
 {
+    InputBlock tmpBlock = inputBlock;
     inputBlock = Block_copy(newInputBlock);
+    Block_release(tmpBlock);
 }
 
 - (void)setOutputBlock:(OutputBlock)newOutputBlock
 {
+    OutputBlock tmpBlock = outputBlock;
     outputBlock = Block_copy(newOutputBlock);
+    Block_release(tmpBlock);
 }
 
 
@@ -786,6 +790,7 @@ void sessionPropertyListener(void *                  inClientData,
     CFStringRef route;
     CheckError( AudioSessionGetProperty(kAudioSessionProperty_AudioRoute, &propertySize, &route), "Couldn't check the audio route");
     self.inputRoute = (NSString *)route;
+    CFRelease(route);
     NSLog(@"AudioRoute: %@", self.inputRoute);
     
     

--- a/Novocaine/RingBuffer.h
+++ b/Novocaine/RingBuffer.h
@@ -32,7 +32,7 @@ class RingBuffer {
 public:	
 	RingBuffer() {};
 	RingBuffer(SInt64 bufferLength, SInt64 numChannels);
-	~RingBuffer() {};
+	~RingBuffer();
 	
 	void AddNewSInt16AudioBuffer(const AudioBuffer aBuffer);
 	void AddNewSInt16Data(const SInt16 *newData, const SInt64 numFrames, const SInt64 whichChannel);

--- a/Novocaine/RingBuffer.mm
+++ b/Novocaine/RingBuffer.mm
@@ -25,8 +25,6 @@
 #include "RingBuffer.h"
 
 
-// TODO: teardown function to release mData
-
 RingBuffer::RingBuffer(SInt64 bufferLength, SInt64 numChannels) : 
 mSizeOfBuffer(bufferLength)
 {
@@ -46,6 +44,13 @@ mSizeOfBuffer(bufferLength)
         mNumUnreadFrames[i] = 0;
 	}
 		
+}
+
+RingBuffer::~RingBuffer() 
+{
+    for (int i=0; i<mNumChannels; i++) {
+        free(mData[i]);
+    }
 }
 
 void RingBuffer::AddNewSInt16AudioBuffer(const AudioBuffer aBuffer)


### PR DESCRIPTION
First of all, thanks for the great library. I am using novocaine for an iOS app I'm working on and I spent a good amount of time running my app through Instruments. In doing so, I found a few memory leaks that were causing my app to consume a lot of memory.

There were a few minor leaks in _Novocaine.m_. I added a destructor to _RingBuffer.m_ to free the `mData` array, and removed the TODO comment :)

The one causing the major memory usage was a bit hard to find. My use case requires creating many instances of _AudioFileReader_'s (each time a user selected a new song) and each time I call `[fileReader play]` which creates the GCD queue. When I go to create another _AudioFileReader_, I call release on the first one but the dealloc method is never called. The reason is because the queue still has a reference to the instance. I added a `stop` method that calls `dispatch_release()`. Now I call `[fileReader stop]` before creating a new one and the memory is deallocated.

This library saved me a ton of time. Great work!
