### PR TITLE
Don't set preferredhardwareioduration for simulator in iOS builds

### DIFF
--- a/Novocaine/Novocaine.m
+++ b/Novocaine/Novocaine.m
@@ -39,7 +39,7 @@
 #define kOutputBus 0
 #define kDefaultDevice 999999
 
-
+#import "TargetConditionals.h"
 
 static Novocaine *audioManager = nil;
 
@@ -232,8 +232,10 @@ static Novocaine *audioManager = nil;
     
     // Set the buffer size, this will affect the number of samples that get rendered every time the audio callback is fired
     // A small number will get you lower latency audio, but will make your processor work harder
+#if !TARGET_IPHONE_SIMULATOR
     Float32 preferredBufferSize = 0.0232;
     CheckError( AudioSessionSetProperty(kAudioSessionProperty_PreferredHardwareIOBufferDuration, sizeof(preferredBufferSize), &preferredBufferSize), "Couldn't set the preferred buffer duration");
+#endif
     
     
     // Set the audio session active


### PR DESCRIPTION
Device was working well,
Simulator builds returned -50 when rendering audio.
If the preferred hardware io duration is set only on iOS but not simulator, the error disappears.
