### PR TITLE
Fix crash on resume from background

### DIFF
--- a/Novocaine/Novocaine.m
+++ b/Novocaine/Novocaine.m
@@ -783,8 +783,13 @@ void sessionPropertyListener(void *                  inClientData,
 							 UInt32                  inDataSize,
 							 const void *            inData){
 	
+    // Determines the reason for the route change, to ensure that it is not
+    //      because of a category change.
+    CFNumberRef routeChangeReasonRef = (CFNumberRef)CFDictionaryGetValue ((CFDictionaryRef)inData, CFSTR (kAudioSession_AudioRouteChangeKey_Reason) );
+    SInt32 routeChangeReason;
+    CFNumberGetValue (routeChangeReasonRef, kCFNumberSInt32Type, &routeChangeReason);
     
-	if (inID == kAudioSessionProperty_AudioRouteChange)
+    if (inID == kAudioSessionProperty_AudioRouteChange && routeChangeReason != kAudioSessionRouteChangeReason_CategoryChange)
     {
         Novocaine *sm = (Novocaine *)inClientData;
         [sm checkSessionProperties];


### PR DESCRIPTION
When resumed from background the sessionPropertyListener is fired and checkSessionProperties is fired, but this causes a crash. Since resuming from background does not involve any Hardware changes checkSessionProperties is not necessary to be fired. 

I've added a check on the route change reason. If the reason is only a category change the checkSessionProperties will not be fired anymore.
