### PR TITLE
Default the signal generator demo to a higher frequency so it can be heard

### DIFF
--- a/Novocaine iOS Example/ViewController.mm
+++ b/Novocaine iOS Example/ViewController.mm
@@ -99,7 +99,7 @@
 //    }];
     
     // SIGNAL GENERATOR!
-//    __block float frequency = 40.0;
+//    __block float frequency = 2000.0;
 //    __block float phase = 0.0;
 //    [self.audioManager setOutputBlock:^(float *data, UInt32 numFrames, UInt32 numChannels)
 //     {


### PR DESCRIPTION
40Hz is too low to be played on iPhone speaker. This caused me to
believe it wasn't working when in fact it was and could just not be
heard. The default should be more clear.
