### PR TITLE
Device channel output fix

### DIFF
--- a/Novocaine/Novocaine.m
+++ b/Novocaine/Novocaine.m
@@ -813,7 +813,13 @@ OSStatus renderCallback (void						*inRefCon,
                 int thisNumChannels = ioData->mBuffers[iBuffer].mNumberChannels;
                 
                 for (int iChannel = 0; iChannel < thisNumChannels; ++iChannel) {
-                    vDSP_vfix16(sm.outData+iChannel, sm.numOutputChannels, (SInt16 *)ioData->mBuffers[iBuffer].mData+iChannel, thisNumChannels, inNumberFrames);
+                    
+                    int interleaveOffset = iChannel;
+                    if (iBuffer < sm.numOutputChannels){
+                        interleaveOffset += iBuffer;
+                    }
+                    
+                    vDSP_vfix16(sm.outData+interleaveOffset, sm.numOutputChannels, (SInt16 *)ioData->mBuffers[iBuffer].mData+iChannel, thisNumChannels, inNumberFrames);
                 }
             }
             


### PR DESCRIPTION
Fix for issue #52 where audio output on device speaker is broken.

This fix is based on the current implementation where Novocaine requests a buffer fill for only the number of available output channels on the device, but the AU render callback always expects a stereo buffer fill.

@alexbw not sure if this is the best long-term solution but it fixes the issue for now.
