### PR TITLE
fixed choppiness problem with AudioFileReader's setCurrentTime:

### DIFF
--- a/Novocaine/AudioFileReader.mm
+++ b/Novocaine/AudioFileReader.mm
@@ -187,13 +187,7 @@
 - (void)setCurrentTime:(float)thisCurrentTime
 {
     dispatch_async(dispatch_get_main_queue(), ^{
-        [self pause];
         ExtAudioFileSeek(self.inputFile, thisCurrentTime*self.samplingRate);
-        
-        [self clearBuffer];
-        [self bufferNewAudio];
-        
-        [self play];
     });
 }
 
@@ -274,6 +268,7 @@
     [self pause];
     if (self.callbackTimer) {
         dispatch_release(self.callbackTimer);
+        self.callbackTimer = nil;
     }
 }
 


### PR DESCRIPTION
On the default iOS example, if you add a timer after 5 seconds to run this:

``` objc
self.fileReader.currentTime = 5
```

The playback gets REALLY choppy. This commit fixes that problem for me; I have no idea if Novocaine is supposed to do this or not, or if this solution was elegant but yeah.
