### PR TITLE
Improve performance and decrease memory use

### DIFF
--- a/Novocaine/Novocaine.h
+++ b/Novocaine/Novocaine.h
@@ -85,7 +85,7 @@ typedef void (^NovocaineInputBlock)(float *data, UInt32 numFrames, UInt32 numCha
 
 
 // Singleton methods
-+ (Novocaine *) audioManager;
++ (instancetype)audioManager;
 
 // Audio Unit methods
 - (void)play;


### PR DESCRIPTION
The inData and outData were always being allocated even when one of
them was unused. Now they are only allocated if they are actually used.
Same thing with the deviceNames array.

It makes no sense to allocate it
with a capacity of 100. `initWithCapacity` should only be used when the
exact final size of the array is known. Instead, the array should
dynamically change its size when new elements are added/removed.

And `dispatch_one` is much quicker than `@synchronized`.
