### PR TITLE
Added clearBuffer when seeking

### DIFF
--- a/Novocaine/AudioFileReader.mm
+++ b/Novocaine/AudioFileReader.mm
@@ -194,6 +194,7 @@
 - (void)setCurrentTime:(float)thisCurrentTime
 {
     dispatch_async(dispatch_get_main_queue(), ^{
+        [self clearBuffer];
         ExtAudioFileSeek(self.inputFile, thisCurrentTime*self.samplingRate);
     });
 }


### PR DESCRIPTION
There was a delay in seeking through an audio file because the ring buffer still has audio ready to be played.