### PR TITLE
Don't hardcode the sampling rate, get it from the hardware

### DIFF
--- a/Novocaine/Novocaine.m
+++ b/Novocaine/Novocaine.m
@@ -415,9 +415,8 @@ static Novocaine *audioManager = nil;
                "Couldn't get the hardware output stream format");
     
     // TODO: check this works on iOS!
-    _inputFormat.mSampleRate = 44100.0;
-    _outputFormat.mSampleRate = 44100.0;
-    self.samplingRate = _inputFormat.mSampleRate;
+    _inputFormat.mSampleRate = self.samplingRate;
+    _outputFormat.mSampleRate = self.samplingRate;
     self.numBytesPerSample = _inputFormat.mBitsPerChannel / 8;
     
     size = sizeof(AudioStreamBasicDescription);


### PR DESCRIPTION
For iOS a sampling rate of 44,100 Hz is hardcoded. For newer iOS devices the sampling rate is 48,000 Hz. This causes a crash on setup. Sampling rate is for iOS already determined from the Hardware.